### PR TITLE
make repeat events workflow safe: do not repeat them if we are just r…

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = {
     };
 
     self.afterInsert = function(req, piece, options, callback) {
-      if (_.has(options, 'workflowMissingLocalesLive')) {
+      if (piece._workflowPropagating) {
         // Workflow is replicating this but also its existing
         // scheduled repetitions, don't re-replicate them and cause problems
         return callback(null);

--- a/index.js
+++ b/index.js
@@ -137,6 +137,11 @@ module.exports = {
     };
 
     self.afterInsert = function(req, piece, options, callback) {
+      if (_.has(options, 'workflowMissingLocalesLive')) {
+        // Workflow is replicating this but also its existing
+        // scheduled repetitions, don't re-replicate them and cause problems
+        return callback(null);
+      }
       if(piece.dateType == 'repeat') {
         return self.repeatEvent(req, piece, callback);
       } else {


### PR DESCRIPTION
…eplicating across locales, in which situation our repetitions will get replicated too already via the original loop