### PR TITLE
repeat events after updating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.0 UNRELEASED
+
+An event can now be repeated (selecting recurring type) after editing it, not only after saving it for the first time.
+
 ### 2.1.8 2022-05-23
 
 Fixes an error that was occurring when trying to save a recurring event.

--- a/index.js
+++ b/index.js
@@ -191,6 +191,9 @@ module.exports = {
       self
         .find(req, { parentId: piece._id, trash: false }, { _id: 1 })
         .toArray(function(err, docs) {
+          if (err) {
+            return callback(err);
+          }
           if (!docs.length) {
             // Replicate event only if it has no replicated events already
             return self.repeatEvent(req, piece, callback);

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ module.exports = {
       return callback(null);
     };
 
-    self.afterInsert = function(req, piece, options, callback) {
+    self.afterSave = function(req, piece, options, callback) {
       if (piece._workflowPropagating) {
         // Workflow is replicating this but also its existing
         // scheduled repetitions, don't re-replicate them and cause problems
@@ -185,9 +185,8 @@ module.exports = {
       }
       if (piece.dateType === 'repeat') {
         return self.repeatEvent(req, piece, callback);
-      } else {
-        return callback(null);
       }
+      return callback(null);
     };
 
     self.denormalizeDatesAndTimes = function(piece) {

--- a/index.js
+++ b/index.js
@@ -183,10 +183,20 @@ module.exports = {
         // scheduled repetitions, don't re-replicate them and cause problems
         return callback(null);
       }
-      if (piece.dateType === 'repeat') {
-        return self.repeatEvent(req, piece, callback);
+
+      if (piece.dateType !== 'repeat') {
+        return callback(null);
       }
-      return callback(null);
+
+      self
+        .find(req, { parentId: piece._id, trash: false }, { _id: 1 })
+        .toArray(function(err, docs) {
+          if (!docs.length) {
+            // Replicate event only if it has no replicated events already
+            return self.repeatEvent(req, piece, callback);
+          }
+          callback(null);
+        });
     };
 
     self.denormalizeDatesAndTimes = function(piece) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Replicate recurring events after updating them, not only after their first insertion into the database.

## What are the specific steps to test this change?

- Checkout this branch
- Link this package to a A2 project
- Create a simple event (single type) and save id
- Edit the event and choose "Recurring" type

![image](https://user-images.githubusercontent.com/8301962/186422909-7fee138e-a370-4c09-a03c-53589df53303.png)

- Save it and check that the event as been replicated to the corresponding dates

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
