### PR TITLE
fix(PRO-5714): pro-use workflowGuid to fix duplicated events when comitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### UNRELEASED
 
-When repeating an event, we were basing our knowledge of wether or not this event already had dupplicates on its parent's `id` but its id would change between versions, resulting in infinite dupplicates when updating an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
+* When repeating an event, we were basing our knowledge of wether or not this event already had dupplicates on its parent's `id` but its id would change between versions, resulting in infinite dupplicates when updating an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
+* Although it caused no apparent issue, the pieces that were dupplicated in a dupplicated event had its parents `hasClones` property set to true (since it was dupplicated and unchanged after that). To make more sense in the pieces, the dupplicates now have the `nowClones` property set to false upon cloning.
 
 ### 2.2.0 2022-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### UNRELEASED
 
-* When repeating an event, we were basing our knowledge of wether or not this event already had dupplicates on its parent's `id` but its id would change between versions, resulting in infinite dupplicates when updating an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
-* Although it caused no apparent issue, the pieces that were dupplicated in a dupplicated event had its parents `hasClones` property set to true (since it was dupplicated and unchanged after that). To make more sense in the pieces, the dupplicates now have the `nowClones` property set to false upon cloning.
+* When repeating an event, we were basing our knowledge of wether or not this event already had duplicates on its parent's `id` but its id would change between versions, resulting in infinite duplicates when comiting an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
+* Although it caused no apparent issue, the pieces that were dupplicated in a dupplicated event had its parents `hasClones` property set to true (since it was dupplicated and unchanged after that). To make more sense in the pieces, the duplicates now have the `nowClones` property set to false upon cloning.
 
 ### 2.2.0 2022-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## UNRELEASED
 
+⚠️ ☝️Due to breking change, MAJOR version should be incremented to `3.0.0`. Please remove this warning when doing so during the release.
+
 * When repeating an event, we were basing our knowledge of whether or not this event already had duplicates, on its parent's `id` but its `id` would change between versions. This resulted in infinite duplicates when committing an event with the `repeat` property. This has been changed to check that its parent's `workflowGuid` does not change across document versions.
+
+**BREAKING CHANGE:** In projects, the way of retrieving parent and children (repeated) events should now be done with `workflowGuid` and `workflowLocale`, and not `_id` anymore.
+
 * Although it caused no apparent issue, the pieces that were duplicated from an event of type `repeat` had its parent's `hasClones` property set to true (since it was duplicated and unchanged after that). To make more sense in the pieces, the duplicates now have the `nowClones` property set to false upon cloning.
 
 ### 2.2.0 2022-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### UNRELEASED
+
+When repeating an event, we were basing our knowledge of wether or not this event already had dupplicates on its parent's `id` but its id would change between versions, resulting in infinite dupplicates when updating an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
+
 ### 2.2.0 2022-08-31
 
 An event can now be repeated (selecting recurring type) after editing it, not only after saving it for the first time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-⚠️ ☝️Due to breking change, MAJOR version should be incremented to `3.0.0`. Please remove this warning when doing so during the release.
+⚠️ ☝️Due to breaking change, MAJOR version should be incremented to `3.0.0`. Please remove this warning when doing so during the release.
 
 * When repeating an event, we were basing our knowledge of whether or not this event already had duplicates, on its parent's `id` but its `id` would change between versions. This resulted in infinite duplicates when committing an event with the `repeat` property. This has been changed to check that its parent's `workflowGuid` does not change across document versions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-### UNRELEASED
+## UNRELEASED
 
-* When repeating an event, we were basing our knowledge of wether or not this event already had duplicates on its parent's `id` but its id would change between versions, resulting in infinite duplicates when comiting an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
-* Although it caused no apparent issue, the pieces that were duplicated from an event of type "repeat" had its parents `hasClones` property set to true (since it was duplicated and unchanged after that). To make more sense in the pieces, the duplicates now have the `nowClones` property set to false upon cloning.
+* When repeating an event, we were basing our knowledge of whether or not this event already had duplicates, on its parent's `id` but its `id` would change between versions. This resulted in infinite duplicates when committing an event with the `repeat` property. This has been changed to check that its parent's `workflowGuid` does not change across document versions.
+* Although it caused no apparent issue, the pieces that were duplicated from an event of type `repeat` had its parent's `hasClones` property set to true (since it was duplicated and unchanged after that). To make more sense in the pieces, the duplicates now have the `nowClones` property set to false upon cloning.
 
 ### 2.2.0 2022-08-31
 

--- a/index.js
+++ b/index.js
@@ -165,6 +165,8 @@ module.exports = {
   },
 
   construct: function(self, options) {
+    // Run migrations:
+    require('./lib/migrations.js')(self, options);
 
     // limit the results of autocomplete for joins
     // so they only include upcoming events

--- a/index.js
+++ b/index.js
@@ -191,8 +191,6 @@ module.exports = {
       self
         .find(req, { parentId: piece.workflowGuid, trash: false }, { _id: 1 })
         .toArray(function(err, docs) {
-          console.log('err', err);
-          console.log('docs', docs);
           if (err) {
             return callback(err);
           }

--- a/index.js
+++ b/index.js
@@ -189,8 +189,10 @@ module.exports = {
       }
 
       self
-        .find(req, { parentId: piece._id, trash: false }, { _id: 1 })
+        .find(req, { parentId: piece.workflowGuid, trash: false }, { _id: 1 })
         .toArray(function(err, docs) {
+          console.log('err', err);
+          console.log('docs', docs);
           if (err) {
             return callback(err);
           }
@@ -245,8 +247,9 @@ module.exports = {
         if (piece.workflowGuid) {
           eventCopy.workflowGuid = self.apos.utils.generateId();
         }
-        eventCopy.parentId = piece._id;
+        eventCopy.parentId = piece.workflowGuid;
         eventCopy.isClone = true;
+        eventCopy.hasClones = false;
         eventCopy.startDate = date;
         eventCopy.endDate = date;
         eventCopy.slug = eventCopy.slug + '-' + date;

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -15,15 +15,20 @@ module.exports = function(self, options) {
         parentId: parent._id,
       }).toArray();
   
-      for (const child of children) {
-        await self.apos.docs.db.update({
-          _id: child._id
-        }, {
-          $set: {
-            parentId: parentWorkflowGuid,
-            hasClones: false,
+      if (children.length) {
+        await self.apos.docs.db.updateMany(
+          {
+            _id: {
+              $in: children.map(child => child._id)
+            }
+          },
+          {
+            $set: {
+              parentId: parentWorkflowGuid,
+              hasClones: false,
+            }
           }
-        });
+        );
       }
     });
   });

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -1,5 +1,5 @@
 module.exports = function(self, options) {
-  self.apos.migrations.add(self.__meta.name + 'update-event-children-parentId', async function() {
+  self.apos.migrations.add(self.__meta.name + ':update-event-children-parentId', async function() {
     // Get all parents' workflowGuid values
     return self.apos.migrations.eachDoc({
       type: 'apostrophe-event',
@@ -8,7 +8,7 @@ module.exports = function(self, options) {
       // Store parentWorkflowGuid value
       const parentWorkflowGuid = parent.workflowGuid;
   
-      // Find all child documents matching the parent's title and having a dateType of 'single'
+      // Find all child documents matching the parent's _id
       // And update their `parentId` value
       const children = await self.apos.docs.db.find({
         type: 'apostrophe-event',

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -1,0 +1,30 @@
+module.exports = function(self, options) {
+  self.apos.migrations.add(self.__meta.name + 'update-event-children-parentId', async function() {
+    // Get all parents' workflowGuid values
+    return self.apos.migrations.eachDoc({
+      type: 'apostrophe-event',
+      dateType: 'repeat'
+    }, async function(parent) {
+      // Store parentWorkflowGuid value
+      const parentWorkflowGuid = parent.workflowGuid;
+  
+      // Find all child documents matching the parent's title and having a dateType of 'single'
+      // And update their `parentId` value
+      const children = await self.apos.docs.db.find({
+        type: 'apostrophe-event',
+        parentId: parent._id,
+      }).toArray();
+  
+      for (const child of children) {
+        await self.apos.docs.db.update({
+          _id: child._id
+        }, {
+          $set: {
+            parentId: parentWorkflowGuid,
+            hasClones: false,
+          }
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Issue Reference

https://linear.app/apostrophecms/issue/PRO-5714/bug-with-recurring-events-on-the-event-calendar-widget-specific-to-the

## Summary

* When repeating an event, we were basing our knowledge of wether or not this event already had dupplicates on its parent's `id` but its id would change between versions, resulting in infinite dupplicates when updating an event with the `repeat` property. This has been to change the check on its parent's `workflowGuid` that does not change accross document versions.
* Although it caused no apparent issue, the pieces that were dupplicated in a dupplicated event had its parents `hasClones` property set to true (since it was dupplicated and unchanged after that). To make more sense in the pieces, the dupplicates now have the `nowClones` property set to false upon cloning.

